### PR TITLE
Keep citrix client active when firefox is closed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,4 +45,17 @@ fi
 
 firefox --new-instance
 
-      
+echo "Firefox closed"
+
+# Check if wfica is (still) running, exit otherwise
+while true;
+do
+  sleep 1
+  PROC_COUNT=$(ps -o command --no-headers --ppid 1|grep wfica|wc -l)
+  if [ "$PROC_COUNT" -eq "0" ]; then
+    echo "Citrix client wfica not found"
+    break
+  fi
+done
+
+echo "Exiting..."


### PR DESCRIPTION
Added a check to evaluate if wfica is still active. Otherwise exit the entrypoint script